### PR TITLE
Remove NilpotentQuotient for fp-groups

### DIFF
--- a/gap/nq.gi
+++ b/gap/nq.gi
@@ -523,22 +523,6 @@ InstallMethod( NilpotentQuotients,
 
 ############################################################################
 ##
-#M  NilpotentQuotient( <FpGroup> )
-##
-InstallOtherMethod( NilpotentQuotient,
-  "for an FpGroup using the LPRES-package", true,
-  [ IsFpGroup, IsPosInt ], -1, # give priority to NQ package
-  function( G, c )
-  return( NilpotentQuotient( Range( IsomorphismLpGroup( G ) ), c ) );
-  end);
-
-InstallOtherMethod( NilpotentQuotient,
-  "for an FpGroup using the LPRES-package", true,
-  [ IsFpGroup ], -1, # give priority to NQ package
-  G -> NilpotentQuotient( Range( IsomorphismLpGroup( G ) ) ) );
-
-############################################################################
-##
 #M  NqEpimorphismNilpotentQuotient( <FpGroup> )
 ##
 InstallOtherMethod( NqEpimorphismNilpotentQuotient,


### PR DESCRIPTION
Under normal circumstances, these are never triggered, and a normal user has
no good way to ever use them.

On the other hand, a pro user can easily get the same effect by replicating
what these methods do.

So all in all, there seems to be no point in having these methods.

In practice, though, due to a fundamental issue with GAP method ranking, it
can happen that lpres' NilpotentQuotient methods for fp-groups actually *do*
end up being ranked higher than the methods from nq, and I'd argue this is
undesirable in general. For details, see
<https://github.com/gap-system/gap/issues/2513>