### PR TITLE
Convert README to markdown

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -46,7 +46,7 @@ SourceRepository := rec(
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", ~.PackageName ),
-README_URL      := Concatenation( ~.PackageWWWHome, "/README" ),
+README_URL      := Concatenation( ~.PackageWWWHome, "/README.md" ),
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,
                                  "/releases/download/v", ~.Version,

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 [![Build Status](https://travis-ci.org/gap-packages/lpres.svg?branch=master)](https://travis-ci.org/gap-packages/lpres)
 [![Code Coverage](https://codecov.io/github/gap-packages/lpres/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/lpres)
 
-The GAP 4 package 'lpres'
-=========================
+# The GAP 4 package `lpres`
 
-Introduction
-------------
+## Introduction
 
-This is the package 'lpres' written for GAP 4. It provides a first
+This is the package `lpres` written for GAP 4. It provides a first
 construction of finitely L-presented groups and a nilpotent quotient
 algorithm for L-presented groups.
 
@@ -24,55 +22,54 @@ The features of this package include
 
   - approximating the Schur multiplier of L-presented groups.
 
-There is a manual in the subdirectory 'doc' written in plain TeX which
+There is a manual in the subdirectory `doc` written in plain TeX which
 describes the functions available.
 
 If you have found a bug or any features missing please let me know
 (Laurent Bartholdi, laurent.bartholdi@gmail.com)
 
 
-Contents
---------
+## Contents
+
 With this version you should have obtained the following files and
 directories:
 
-  README.lpres    this file
+    README.lpres    this file
+    
+    init.g          the file that initializes this package
+    
+    read.g          the file that reads in the package        
+    
+    makedoc.g       the file used to compile the documentation
+    
+    PackageInfo.g   the file for the new package loading mechanism
+    
+    doc             the manual
+    
+    gap             the GAP code
 
-  init.g          the file that initializes this package
 
-  read.g          the file that reads in the package        
-
-  makedoc.g       the file used to compile the documentation
-
-  PackageInfo.g   the file for the new package loading mechanism
-
-  doc             the manual
-
-  gap             the GAP code
-
-
-Installation
-------------
+## Installation
 
 Make sure that the GAP 4 packages Polycyclic and FGA are installed. It
-suffices to unpack the package in the 'pkg' directory and load the
-package from within gap using `LoadPackage("lpres");'.
+suffices to unpack the package in the `pkg` directory and load the
+package from within gap using `LoadPackage("lpres");`.
 
 
-Test-Files
-----------
+## Test Files
 
-The lpres-package can be tested with `ReadPackage("lpres","tst/testall.gi");'.
+The lpres package can be tested with
+
+    ReadPackage("lpres","tst/testall.g");
 
 
-Compiling the Manual
---------------------
+## Compiling the Manual
 
 If you obtained the package from its git repository, you have to compile
 the manual. For this, enter the directory of lpres (the one containing
-the file makedoc.g) and run `gap makedoc.g'.
+the file `makedoc.g`) and run `gap makedoc.g`.
 
-BugFixes/Changes/Features Added
------------------------------
-- Version 0.1.0:
-                - maintenance taken over by Laurent Bartholdi
+## BugFixes/Changes/Features Added
+
+* Version 0.1.0:
+  - maintenance taken over by Laurent Bartholdi


### PR DESCRIPTION
This better renders it on GitHub and GitHub pages and properly displays Travis and CodeCov badges.

Closes #9.