### PR TITLE
Don't use \GAP4 and \cite in lpres.bib

### DIFF
--- a/doc/lpres.bib
+++ b/doc/lpres.bib
@@ -290,14 +290,14 @@ MRREVIEWER = {V. D. Mazurov},
 @manual{nq,
   author = {Nickel, Werner},
   title  = {NQ},
-  note   = {A {\GAP4} package, see \cite{GAP4}},
+  note   = {A GAP4 package},
   year   = {2003}
 }
 
 @manual{ParGap,
   author = {Cooperman, Gene},
   title  = {ParGAP},
-  note   = {A {\GAP4} package, see \cite{GAP4}},
+  note   = {A GAP4 package},
   year   = {2004}
 }
 


### PR DESCRIPTION
This doesn't (properly) work and causes errors.